### PR TITLE
Fixed a bug where mk_dateWithoutTime would return nil

### DIFF
--- a/Source/NSDate/NSDate+MK_Creation.m
+++ b/Source/NSDate/NSDate+MK_Creation.m
@@ -68,13 +68,12 @@
 }
 
 - (NSDate *)mk_dateWithoutTime {
-    NSString *formattedString = [self mk_formattedString];
-
-    NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
-    [formatter setDateFormat:[NSDate mk_dateFormatDDMMYYYYDashed]];
-    NSDate *result = [formatter dateFromString:formattedString];
-    
+    unsigned int flags = NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitDay;
+    NSCalendar* calendar = [NSCalendar currentCalendar];
+    NSDateComponents* components = [calendar components:flags fromDate:self];
+    NSDate* result = [[calendar dateFromComponents:components] dateByAddingTimeInterval:[[NSTimeZone localTimeZone]secondsFromGMT]];
     return result;
+
 }
 
 @end


### PR DESCRIPTION
Sometimes with no apparent reason, `mk_dateWithoutTime` would return `nil`
This PR fixes that problem, plus, it might be more efficient this way (compared to using reverse formatting).
